### PR TITLE
feat: clips scene integration with OBS, belabox, and channel points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,12 @@ title, GitHub user status, OBS overlay, and OBS recording filenames.
 | Script | What it does |
 |--------|-------------|
 | `topic` | Sets current topic, syncs to Twitch, YouTube, GitHub status |
+| `topicsd` | Daemon: HTTP server + Twitch EventSub + OBS watcher + clips syncer |
+| `category` | fzf-based Twitch category picker; sets category and updates local cache |
+| `clips` | sqlite3 wrapper for `clips.db`; always regenerates weighted-shuffled `clips.m3u` |
+| `sync-clips` | Fetches all Twitch clips, downloads MP4s, manages `clips.db` and `clips.m3u` |
+| `what` | Prints current topic + live Twitch category; pbcopy of topic |
+| `setup-categories` | Symlinks `~/.config/twitch/categories` to `categories.sample` in repo |
 | `service-current-topic` | HTTP server (default port 8080) serving line 1 of `~/.topics`; background poller syncs Twitch title changes into the file |
 | `service-rename-recording` | Watches OBS via WebSocket; renames recordings to a slug of the current topic when recording stops |
 | `cache-twitch-token` | Refreshes/caches Twitch OAuth token via `twitch` CLI |
@@ -36,19 +42,25 @@ second and displays the topic in a top bar alongside a clock and logo.
 | Variable | Default | Used by |
 |----------|---------|---------|
 | `TOPICS` / `TOPIC` | `~/.topics` | all scripts |
-| `PORT` | `8080` | `service-current-topic` |
-| `TWITCH_POLL` | `60` | `service-current-topic` |
-| `TWITCH_BROADCASTER_ID` | (required) | `topic`, `service-current-topic` |
+| `PORT` | `8080` | `topicsd` |
+| `TWITCH_POLL` | `60` | `topicsd` |
+| `TWITCH_BROADCASTER_ID` | (required) | `topic`, `topicsd`, `sync-clips` |
 | `YOUTUBE_BROADCAST_ID` | (auto-detected) | `topic` |
 | `YOUTUBE_BROADCAST_STATUS` | `active` | `topic` |
 | `YOUTUBE_TOKEN_FILE` | `~/.config/youtube/token.json` | `topic`, `cache-yt-token` |
 | `YT_LOOPBACK_PORT` | `53682` | `cache-yt-token` |
-| `OBS_WS_URL` | `ws://127.0.0.1:4455` | `service-rename-recording` |
-| `OBS_WS_PASSWORD_FILE` | `~/.config/obs-websocket/password` | `service-rename-recording` |
+| `OBS_WS_URL` | `ws://127.0.0.1:4455` | `topicsd` |
+| `OBS_WS_PASSWORD_FILE` | `~/.config/obs-websocket/password` | `topicsd` |
+| `CLIPS_DIR` | `~/.clips` | `sync-clips`, `clips`, `topicsd` |
+| `CLIPS_SYNC_INTERVAL` | `3600` | `topicsd` |
+| `OBS_CLIPS_SCENE` | `Clips` | `topicsd` |
+| `OBS_BELABOX_SOURCE` | `belabox` | `topicsd` |
+| `OBS_VLC_SOURCE` | `clips` | `topicsd` |
+| `OBS_CLIPS_REWARD` | `play clip` | `topicsd` |
 
 ## External tool dependencies
 
-`twitch` CLI, `gh`, `jq`, `curl`, `nc`, `websocat`, `openssl`, `perl`, `git`
+`twitch` CLI, `gh`, `jq`, `curl`, `nc`, `websocat`, `openssl`, `perl`, `git`, `sqlite3` (pre-installed on macOS), `fzf`
 
 ## Conventions
 
@@ -57,6 +69,10 @@ second and displays the topic in a top bar alongside a clock and logo.
 - `mktemp` + `mv` for atomic file writes
 - Coproc pattern (`coproc NETCAT { nc -l "$port"; }`) for the HTTP server loop
 - Topic truncated to 140 chars when sent to Twitch
+- `clips.db` SQLite schema uses `INSERT OR IGNORE` on `twitch_id` to preserve stable integer `id`
+- Weighted shuffle: `perl -MList::Util=shuffle` (not `shuf`, which is GNU-only)
+- OBS clips scene auto-switch: `eventSubscriptions:324` (64=Outputs + 256=MediaInputs + 4=Scenes)
+- Clip request IPC: `$CLIPS_DIR/clip-request` temp file written by EventSub, read by OBS watcher
 
 ## Commit style
 

--- a/clips
+++ b/clips
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+clips_dir="${CLIPS_DIR:-$HOME/.clips}"
+db="$clips_dir/clips.db"
+
+need() {
+	command -v "$1" >/dev/null 2>&1 || {
+		printf 'clips: missing command: %s\n' "$1" >&2
+		exit 1
+	}
+}
+
+need sqlite3
+need perl
+
+[[ -f "$db" ]] || {
+	printf 'clips: database not found: %s\n' "$db" >&2
+	printf 'clips: run sync-clips first\n' >&2
+	exit 1
+}
+
+regen_m3u() {
+	[[ -f "$db" ]] || return 0
+	sqlite3 "$db" \
+		"SELECT twitch_id, MAX(1, CAST(ROUND(weight) AS INTEGER)) FROM clips WHERE downloaded=1" |
+		while IFS='|' read -r cid reps; do
+			i=0
+			while [[ $i -lt $reps ]]; do
+				printf '%s/%s.mp4\n' "$clips_dir" "$cid"
+				i=$((i + 1))
+			done
+		done |
+		perl -MList::Util=shuffle -e 'print shuffle <STDIN>' \
+		>"$clips_dir/clips.m3u.tmp" && mv "$clips_dir/clips.m3u.tmp" "$clips_dir/clips.m3u" || true
+}
+
+trap regen_m3u EXIT
+
+if [[ $# -eq 0 ]]; then
+	sqlite3 "$db" || true
+else
+	sqlite3 "$db" "$*"
+fi

--- a/sync-clips
+++ b/sync-clips
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+clips_dir="${CLIPS_DIR:-$HOME/.clips}"
+broadcaster_id="${TWITCH_BROADCASTER_ID:-}"
+
+need() {
+	command -v "$1" >/dev/null 2>&1 || {
+		printf 'sync-clips: missing command: %s\n' "$1" >&2
+		exit 1
+	}
+}
+
+need twitch
+need jq
+need curl
+need sqlite3
+need perl
+
+[[ -n "$broadcaster_id" ]] || {
+	printf 'sync-clips: TWITCH_BROADCASTER_ID not set\n' >&2
+	exit 1
+}
+
+mkdir -p "$clips_dir"
+
+sqlite3 "$clips_dir/clips.db" "
+CREATE TABLE IF NOT EXISTS clips (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  twitch_id        TEXT    UNIQUE NOT NULL,
+  title            TEXT    DEFAULT '',
+  url              TEXT    DEFAULT '',
+  embed_url        TEXT    DEFAULT '',
+  broadcaster_id   TEXT    DEFAULT '',
+  broadcaster_name TEXT    DEFAULT '',
+  creator_id       TEXT    DEFAULT '',
+  creator_name     TEXT    DEFAULT '',
+  video_id         TEXT    DEFAULT '',
+  game_id          TEXT    DEFAULT '',
+  language         TEXT    DEFAULT '',
+  view_count       INTEGER DEFAULT 0,
+  created_at       TEXT    DEFAULT '',
+  thumbnail_url    TEXT    DEFAULT '',
+  duration         REAL    DEFAULT 0,
+  vod_offset       REAL,
+  is_featured      INTEGER DEFAULT 0,
+  weight           REAL    DEFAULT 1.0,
+  description      TEXT    DEFAULT '',
+  summary          TEXT    DEFAULT '',
+  downloaded       INTEGER DEFAULT 0
+);"
+
+regen_m3u() {
+	sqlite3 "$clips_dir/clips.db" \
+		"SELECT twitch_id, MAX(1, CAST(ROUND(weight) AS INTEGER)) FROM clips WHERE downloaded=1" |
+		while IFS='|' read -r cid reps; do
+			i=0
+			while [[ $i -lt $reps ]]; do
+				printf '%s/%s.mp4\n' "$clips_dir" "$cid"
+				i=$((i + 1))
+			done
+		done |
+		perl -MList::Util=shuffle -e 'print shuffle <STDIN>' \
+		>"$clips_dir/clips.m3u.tmp" && mv "$clips_dir/clips.m3u.tmp" "$clips_dir/clips.m3u"
+	printf 'sync-clips: m3u regenerated (%d entries)\n' \
+		"$(wc -l <"$clips_dir/clips.m3u" 2>/dev/null | tr -d ' ' || echo 0)" >&2
+}
+
+cursor=""
+fetched=0
+
+while :; do
+	if [[ -n "$cursor" ]]; then
+		response="$(twitch api get clips \
+			-q "broadcaster_id=$broadcaster_id" \
+			-q "first=100" \
+			-q "after=$cursor" 2>/dev/null)" || break
+	else
+		response="$(twitch api get clips \
+			-q "broadcaster_id=$broadcaster_id" \
+			-q "first=100" 2>/dev/null)" || break
+	fi
+
+	count="$(jq '.data | length' <<<"$response" 2>/dev/null || echo 0)"
+	[[ "$count" -gt 0 ]] || break
+
+	jq -r '
+	.data[] |
+	"INSERT OR IGNORE INTO clips (twitch_id,title,url,embed_url,broadcaster_id,broadcaster_name,creator_id,creator_name,video_id,game_id,language,view_count,created_at,thumbnail_url,duration,vod_offset,is_featured) VALUES (" +
+	(.id|@json) + "," +
+	(.title|@json) + "," +
+	(.url|@json) + "," +
+	(.embed_url|@json) + "," +
+	(.broadcaster_id|@json) + "," +
+	(.broadcaster_name|@json) + "," +
+	(.creator_id|@json) + "," +
+	(.creator_name|@json) + "," +
+	((.video_id // "")|@json) + "," +
+	((.game_id // "")|@json) + "," +
+	((.language // "")|@json) + "," +
+	(.view_count|tostring) + "," +
+	(.created_at|@json) + "," +
+	(.thumbnail_url|@json) + "," +
+	(.duration|tostring) + "," +
+	(if .vod_offset == null then "NULL" else (.vod_offset|tostring) end) + "," +
+	(if .is_featured then "1" else "0" end) + ");"
+	' <<<"$response" | sqlite3 "$clips_dir/clips.db" 2>/dev/null || true
+
+	fetched=$((fetched + count))
+	cursor="$(jq -r '.pagination.cursor // empty' <<<"$response" 2>/dev/null || true)"
+	[[ -n "$cursor" ]] || break
+done
+
+printf 'sync-clips: fetched metadata for %d clips\n' "$fetched" >&2
+
+downloaded=0
+skipped=0
+
+while IFS='|' read -r twitch_id thumbnail_url; do
+	[[ -n "$twitch_id" ]] || continue
+	dest="$clips_dir/$twitch_id.mp4"
+
+	if [[ -f "$dest" ]]; then
+		sqlite3 "$clips_dir/clips.db" \
+			"UPDATE clips SET downloaded=1 WHERE twitch_id='$twitch_id' AND downloaded=0;" 2>/dev/null || true
+		skipped=$((skipped + 1))
+		continue
+	fi
+
+	mp4_url="${thumbnail_url/-preview-480x272.jpg/.mp4}"
+	tmp="$(mktemp)"
+	if curl -fsSL -o "$tmp" "$mp4_url" 2>/dev/null; then
+		mv "$tmp" "$dest"
+		sqlite3 "$clips_dir/clips.db" \
+			"UPDATE clips SET downloaded=1 WHERE twitch_id='$twitch_id';" 2>/dev/null || true
+		downloaded=$((downloaded + 1))
+		printf 'sync-clips: downloaded %s\n' "$twitch_id" >&2
+	else
+		rm -f "$tmp"
+		printf 'sync-clips: download failed: %s\n' "$twitch_id" >&2
+	fi
+done < <(sqlite3 "$clips_dir/clips.db" \
+	"SELECT twitch_id, thumbnail_url FROM clips WHERE downloaded=0")
+
+printf 'sync-clips: %d downloaded, %d already present\n' "$downloaded" "$skipped" >&2
+
+regen_m3u

--- a/topicsd
+++ b/topicsd
@@ -7,6 +7,12 @@ obs_ws_url="${OBS_WS_URL:-ws://127.0.0.1:4455}"
 obs_ws_password_file="${OBS_WS_PASSWORD_FILE:-$HOME/.config/obs-websocket/password}"
 obs_reconnect_delay="${RECONNECT_DELAY:-2}"
 log_prefix="${LOG_PREFIX:-topic-service}"
+clips_dir="${CLIPS_DIR:-$HOME/.clips}"
+clips_sync_interval="${CLIPS_SYNC_INTERVAL:-3600}"
+obs_clips_scene="${OBS_CLIPS_SCENE:-Clips}"
+obs_belabox_source="${OBS_BELABOX_SOURCE:-belabox}"
+obs_vlc_source="${OBS_VLC_SOURCE:-clips}"
+obs_clips_reward="${OBS_CLIPS_REWARD:-play clip}"
 
 need() {
 	command -v "$1" >/dev/null 2>&1 || {
@@ -148,8 +154,19 @@ rename_recording() {
 	log "    to: $dest"
 }
 
+obs_send_request() {
+	local request_type="$1" request_data="${2:-{}}"
+	jq -cn \
+		--arg rt "$request_type" \
+		--arg rid "req-$$-$RANDOM" \
+		--argjson rd "$request_data" \
+		'{op:6,d:{requestType:$rt,requestId:$rid,requestData:$rd}}' \
+		>&"${OBSWS[1]}" 2>/dev/null || true
+}
+
 obs_connect_and_watch() {
-	local hello salt challenge auth identify line event_type output_path
+	local hello salt challenge auth identify line op event_type input_name output_path rc
+	local _current_scene="" _prev_scene="" _clip_req_active=0
 
 	load_password
 
@@ -171,9 +188,9 @@ obs_connect_and_watch() {
 		}
 		auth="$(obs_auth_string "$OBS_WS_PASSWORD" "$salt" "$challenge")"
 		identify="$(jq -cn --arg auth "$auth" \
-			'{op:1,d:{rpcVersion:1,authentication:$auth,eventSubscriptions:64}}')"
+			'{op:1,d:{rpcVersion:1,authentication:$auth,eventSubscriptions:324}}')"
 	else
-		identify="$(jq -cn '{op:1,d:{rpcVersion:1,eventSubscriptions:64}}')"
+		identify="$(jq -cn '{op:1,d:{rpcVersion:1,eventSubscriptions:324}}')"
 	fi
 
 	printf '%s\n' "$identify" >&"${OBSWS[1]}"
@@ -191,18 +208,98 @@ obs_connect_and_watch() {
 
 	log "connected to OBS at $obs_ws_url"
 
-	while IFS= read -r -u "${OBSWS[0]}" line; do
-		line="$(printf '%s' "$line" | trim_cr)"
-		[[ -n "$line" ]] || continue
-		[[ "$(jq -r '.op // empty' <<<"$line")" == "5" ]] || continue
+	obs_send_request "GetCurrentProgramScene"
 
-		event_type="$(jq -r '.d.eventType // empty' <<<"$line")"
-		[[ "$event_type" == "RecordStateChanged" ]] || continue
+	while :; do
+		line=""
+		IFS= read -r -u "${OBSWS[0]}" -t 1 line
+		rc=$?
 
-		output_path="$(jq -r '.d.eventData.outputPath // empty' <<<"$line")"
-		[[ -n "$output_path" ]] || continue
+		if [[ $rc -ne 0 ]]; then
+			kill -0 "${OBSWS_PID:-0}" 2>/dev/null || break
+		fi
 
-		rename_recording "$output_path"
+		if [[ -n "$line" ]]; then
+			line="$(printf '%s' "$line" | trim_cr)"
+			op="$(jq -r '.op // empty' <<<"$line")"
+
+			if [[ "$op" == "7" ]]; then
+				if [[ "$(jq -r '.d.requestType // empty' <<<"$line")" == "GetCurrentProgramScene" ]]; then
+					_current_scene="$(jq -r '.d.responseData.currentProgramSceneName // empty' <<<"$line")"
+				fi
+
+			elif [[ "$op" == "5" ]]; then
+				event_type="$(jq -r '.d.eventType // empty' <<<"$line")"
+
+				case "$event_type" in
+				RecordStateChanged)
+					output_path="$(jq -r '.d.eventData.outputPath // empty' <<<"$line")"
+					[[ -n "$output_path" ]] && rename_recording "$output_path"
+					;;
+				CurrentProgramSceneChanged)
+					_current_scene="$(jq -r '.d.eventData.sceneName // empty' <<<"$line")"
+					;;
+				MediaInputPlaybackEnded)
+					input_name="$(jq -r '.d.eventData.inputName // empty' <<<"$line")"
+					if [[ "$input_name" == "$obs_belabox_source" ]]; then
+						_prev_scene="$_current_scene"
+						obs_send_request "SetCurrentProgramScene" \
+							"$(jq -cn --arg n "$obs_clips_scene" '{sceneName:$n}')"
+						obs_send_request "TriggerMediaInputAction" \
+							"$(jq -cn --arg n "$obs_vlc_source" '{inputName:$n,mediaAction:"OBS_WEBSOCKET_MEDIA_INPUT_ACTION_RESTART"}')"
+						log "belabox ended: switched to $obs_clips_scene"
+					elif [[ "$input_name" == "$obs_vlc_source" && $_clip_req_active -eq 1 ]]; then
+						obs_send_request "SetInputSettings" \
+							"$(jq -cn --arg n "$obs_vlc_source" --arg p "$clips_dir/clips.m3u" \
+								'{inputName:$n,inputSettings:{playlist:[{value:$p,hidden:false,selected:false}]}}')"
+						obs_send_request "TriggerMediaInputAction" \
+							"$(jq -cn --arg n "$obs_vlc_source" '{inputName:$n,mediaAction:"OBS_WEBSOCKET_MEDIA_INPUT_ACTION_RESTART"}')"
+						if [[ -n "$_prev_scene" ]]; then
+							obs_send_request "SetCurrentProgramScene" \
+								"$(jq -cn --arg n "$_prev_scene" '{sceneName:$n}')"
+							log "clip request done: restored to $_prev_scene"
+							_prev_scene=""
+						fi
+						_clip_req_active=0
+					fi
+					;;
+				MediaInputPlaybackStarted)
+					input_name="$(jq -r '.d.eventData.inputName // empty' <<<"$line")"
+					if [[ "$input_name" == "$obs_belabox_source" && -n "$_prev_scene" ]]; then
+						obs_send_request "SetCurrentProgramScene" \
+							"$(jq -cn --arg n "$_prev_scene" '{sceneName:$n}')"
+						log "belabox started: restored to $_prev_scene"
+						_prev_scene=""
+					fi
+					;;
+				esac
+			fi
+		fi
+
+		local req_file="$clips_dir/clip-request"
+		if [[ -f "$req_file" && $_clip_req_active -eq 0 ]]; then
+			local req_id
+			req_id="$(cat "$req_file" 2>/dev/null || true)"
+			rm -f "$req_file"
+			if [[ -n "$req_id" ]]; then
+				local req_mp4="$clips_dir/$req_id.mp4"
+				if [[ -f "$req_mp4" ]]; then
+					printf '%s\n' "$req_mp4" >"$clips_dir/clips-request.m3u"
+					_prev_scene="$_current_scene"
+					obs_send_request "SetInputSettings" \
+						"$(jq -cn --arg n "$obs_vlc_source" --arg p "$clips_dir/clips-request.m3u" \
+							'{inputName:$n,inputSettings:{playlist:[{value:$p,hidden:false,selected:false}]}}')"
+					obs_send_request "TriggerMediaInputAction" \
+						"$(jq -cn --arg n "$obs_vlc_source" '{inputName:$n,mediaAction:"OBS_WEBSOCKET_MEDIA_INPUT_ACTION_RESTART"}')"
+					obs_send_request "SetCurrentProgramScene" \
+						"$(jq -cn --arg n "$obs_clips_scene" '{sceneName:$n}')"
+					_clip_req_active=1
+					log "playing requested clip: $req_id"
+				else
+					log "requested clip not found locally: $req_id"
+				fi
+			fi
+		fi
 	done
 
 	return 1
@@ -254,22 +351,65 @@ _twitch_eventsub() {
 			sleep 2; continue
 		}
 
+		if [[ -n "${obs_clips_reward:-}" ]]; then
+			twitch api post eventsub/subscriptions -b "$(jq -cn \
+				--arg bid "$TWITCH_BROADCASTER_ID" \
+				--arg sid "$session_id" \
+				'{type:"channel.channel_points_custom_reward_redemption.add",version:"1",condition:{broadcaster_user_id:$bid},transport:{method:"websocket",session_id:$sid}}'
+			)" >/dev/null 2>&1 || true
+		fi
+
 		while IFS= read -r -u "${WS[0]}" line; do
 			[[ -n "$line" ]] || continue
 			[[ "$(jq -r '.metadata.message_type // empty' <<<"$line")" == "notification" ]] || continue
-			[[ "$(jq -r '.metadata.subscription_type // empty' <<<"$line")" == "channel.update" ]] || continue
 
-			title="$(jq -r '.payload.event.title // empty' <<<"$line")"
-			[[ -n "$title" ]] || continue
+			sub_type="$(jq -r '.metadata.subscription_type // empty' <<<"$line")"
 
-			current="$(sed -n '1p' "$topics" 2>/dev/null || true)"
-			[[ "$title" != "$current" ]] || continue
+			case "$sub_type" in
+			channel.update)
+				title="$(jq -r '.payload.event.title // empty' <<<"$line")"
+				[[ -n "$title" ]] || continue
 
-			topic "$title" >/dev/null
+				current="$(sed -n '1p' "$topics" 2>/dev/null || true)"
+				[[ "$title" != "$current" ]] || continue
+
+				topic "$title" >/dev/null
+				;;
+			channel.channel_points_custom_reward_redemption.add)
+				[[ -n "${obs_clips_reward:-}" ]] || continue
+				reward_title="$(jq -r '.payload.event.reward.title // empty' <<<"$line")"
+				[[ "$reward_title" == "$obs_clips_reward" ]] || continue
+
+				user_input="$(jq -r '.payload.event.user_input // empty' <<<"$line")"
+				[[ "$user_input" =~ ^[0-9]+$ ]] || continue
+
+				clip_twitch_id="$(sqlite3 "$clips_dir/clips.db" \
+					"SELECT twitch_id FROM clips WHERE id=$user_input AND downloaded=1 LIMIT 1;" \
+					2>/dev/null || true)"
+				[[ -n "$clip_twitch_id" ]] || {
+					log "clip #$user_input not found or not downloaded"
+					continue
+				}
+
+				printf '%s\n' "$clip_twitch_id" >"$clips_dir/clip-request"
+				log "clip request queued: #$user_input ($clip_twitch_id)"
+				;;
+			esac
 		done
 
 		eval "exec ${WS[1]}>&-" 2>/dev/null
 		sleep 2
+	done
+}
+
+# --- Clips syncer -----------------------------------------------------------
+
+_clips_syncer() {
+	while :; do
+		command -v twitch >/dev/null 2>&1 || { sleep 10; continue; }
+		[[ -n "${TWITCH_BROADCASTER_ID:-}" ]] || { sleep 10; continue; }
+		sync-clips >/dev/null 2>&1 || true
+		sleep "$clips_sync_interval"
 	done
 }
 
@@ -281,7 +421,9 @@ _twitch_eventsub &
 _eventsub_pid=$!
 _obs_watcher &
 _obs_pid=$!
-trap 'kill "$_eventsub_pid" "$_obs_pid" 2>/dev/null' EXIT
+_clips_syncer &
+_clips_pid=$!
+trap 'kill "$_eventsub_pid" "$_obs_pid" "$_clips_pid" 2>/dev/null' EXIT
 
 while :; do
 	coproc NETCAT { nc -l "$port"; } 2>/dev/null || { sleep 1; continue; }


### PR DESCRIPTION
## Overview

Auto-switch OBS to a Clips scene when the belabox IRL source drops, play locally cached Twitch clips via OBS VLC Video Source, and allow viewers to request specific clips via channel points.

## New scripts

### `sync-clips`
- Paginated fetch of all Twitch clips via `/helix/clips`
- Stores full metadata in `$CLIPS_DIR/clips.db` (SQLite)
- Downloads MP4s from Twitch CDN (thumbnail_url trick)
- Generates `clips.m3u` with weighted shuffle via `perl -MList::Util=shuffle`
- Skips already-downloaded clips on re-runs

### `clips`
- Thin wrapper: `clips [sql]` runs sqlite3 on `clips.db`
- Always regenerates weighted-shuffled `clips.m3u` after any invocation
- No args opens interactive sqlite3 shell

## `clips.db` schema
All Twitch API clip fields + `weight` (REAL, default 1.0), `description`, `summary` (fill in manually later), `downloaded`.

Stable AUTOINCREMENT `id` — never reassigned. Viewers can bookmark clip numbers permanently.

## `topicsd` changes

- `eventSubscriptions` 64 → 324 (adds MediaInputs + Scenes)
- `obs_send_request()`: helper to send op:6 requests
- Tracks current OBS scene via `CurrentProgramSceneChanged` events
- **Belabox drop** (`MediaInputPlaybackEnded`): saves scene, switches to `$OBS_CLIPS_SCENE`, restarts VLC
- **Belabox resume** (`MediaInputPlaybackStarted`): restores previous scene
- **Channel points**: subscribes to `channel.channel_points_custom_reward_redemption.add`; viewer redeems `$OBS_CLIPS_REWARD` and enters clip integer ID; queues to `clip-request` file
- **On-demand clip**: OBS watcher polls `clip-request` (1s loop), plays clip via `SetInputSettings` + `TriggerMediaInputAction`, restores playlist on completion
- `_clips_syncer`: background worker — runs `sync-clips` on startup + every `$CLIPS_SYNC_INTERVAL` seconds

## OBS setup (one-time manual)
1. `brew install vlc`
2. Create a "Clips" scene in OBS
3. Add OBS VLC Video Source pointing to `~/.clips/clips.m3u`, set **loop on, shuffle off**
4. Create a Twitch channel points reward named "play clip" (or set `$OBS_CLIPS_REWARD`)

## New env vars
| Variable | Default | Purpose |
|---|---|---|
| CLIPS_DIR | ~/.clips | clips.db and MP4 storage |
| CLIPS_SYNC_INTERVAL | 3600 | seconds between syncs |
| OBS_CLIPS_SCENE | Clips | scene to switch to on belabox drop |
| OBS_BELABOX_SOURCE | belabox | media source to watch |
| OBS_VLC_SOURCE | clips | VLC source name in Clips scene |
| OBS_CLIPS_REWARD | play clip | channel points reward title |

## macOS compatible
sqlite3 pre-installed, perl pre-installed. No GNU-only tools.